### PR TITLE
ENH: Add datalad installation via conda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -656,6 +656,8 @@ RUN \
     # Install Intel(R) Compiler Runtime - numba optimization
     # TODO: don't install, results in memory error
     # conda install -y --freeze-installed -c numba icc_rt && \
+    # datalad for data management and access to vast range of existing data
+    conda install -y -c conda-forge datalad && \
     # Install full pip requirements
     pip install --no-cache-dir --upgrade --upgrade-strategy only-if-needed -r ${RESOURCES_PATH}/libraries/requirements-full.txt && \
     # Setup Spacy


### PR DESCRIPTION
It will also install git-annex which datalad uses for management of large
files.

Since it is just a "tool", I have not used --freeze-installed to benefit from
possible upgrades etc.

It could also be installed from stock ubuntu, but would be an older version.
Also backports are available from NeuroDebian, but I have decided to just go with
conda installation for now.

Closes #50

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] New Feature
- [ ] Feature Improvment
- [ ] Refactoring
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
<!--- Use this section to describe your changes.  Why is this change required? What problem does it solve? If your test fixes a specific issue, don't forget to reference the issue number. If your PR is still a work in progress, that's totally fine – just include a note to let us know. -->

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I have read the [CONTRIBUTING](https://github.com/ml-tooling/ml-workspace/blob/main/CONTRIBUTING.md) document.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
